### PR TITLE
Skaufman.xs core only

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -6,6 +6,7 @@ copyright_holder = David Golden
 [Prereqs / TestRequires]
 Class::Load::XS = 0
 Module::CoreList = 0
+version = 0
 
 [@DAGOLDEN]
 AutoMetaResources.bugtracker.rt = 0

--- a/dist.ini
+++ b/dist.ini
@@ -5,6 +5,7 @@ copyright_holder = David Golden
 
 [Prereqs / TestRequires]
 Class::Load::XS = 0
+Module::CoreList = 0
 
 [@DAGOLDEN]
 AutoMetaResources.bugtracker.rt = 0

--- a/lib/Test/NoXS.pm
+++ b/lib/Test/NoXS.pm
@@ -89,6 +89,9 @@ sub test_module_in_core {
     # Disable all XS loading
     use Test::NoXS ':all';
 
+    # Disable all XS loading except core modules
+    use Test::NoXS ':xs_core_only';
+
 =head1 DESCRIPTION
 
 This modules hijacks L<DynaLoader> and L<XSLoader> to prevent them from loading
@@ -100,7 +103,8 @@ pure-Perl alternative.
 
 Modules that should not load XS should be given as a list of arguments to C<use
 Test::NoXS>.  Alternatively, giving ':all' as an argument will disable all
-future attempts to load XS.
+future attempts to load XS. Passing ':xs_core_only' works like ':all' but will
+allow loading of core modules that have not been upgraded from the core version.
 
 =cut
 

--- a/lib/Test/NoXS.pm
+++ b/lib/Test/NoXS.pm
@@ -10,6 +10,8 @@ my @no_xs_modules;
 my $no_xs_all;
 my $xs_core_only;
 
+our $PERL_CORE_VERSION = $];
+
 sub import {
     my $class = shift;
     if  ( grep { /:all/ } @_ ) {
@@ -24,10 +26,10 @@ sub import {
 }
 
 #die unless module is in core and hasn't been upgraded.
-sub _module_in_core {
+sub test_module_in_core {
     my $caller = shift;
     die "XS disabled for non-core modules" unless Module::CoreList::is_core( $caller );
-    my $core_module_version = $Module::CoreList::version{$]}{$caller};
+    my $core_module_version = $Module::CoreList::version{$PERL_CORE_VERSION}{$caller};
     my $module_version = $caller->VERSION;
     if( $core_module_version != $module_version ) {
         die "$caller installed version: $module_version"
@@ -48,7 +50,7 @@ sub _module_in_core {
         my $caller = @_ ? $_[0] : caller;
         die "XS disabled" if $no_xs_all;
         die "XS disable for $caller" if grep { $caller eq $_ } @no_xs_modules;
-        if( $xs_core_only && _module_in_core( $caller )) {
+        if( $xs_core_only && test_module_in_core( $caller )) {
             goto $bootstrap_orig;
         }
         goto $bootstrap_orig;
@@ -61,7 +63,7 @@ sub _module_in_core {
             my $caller = @_ ? $_[0] : caller;
             die "XS disabled" if $no_xs_all;
             die "XS disable for $caller" if grep { $caller eq $_ } @no_xs_modules;
-            if( $xs_core_only && _module_in_core( $caller )) {
+            if( $xs_core_only && test_module_in_core( $caller )) {
                 goto $bootstrap_orig;
             }
             goto $xsload_orig;

--- a/lib/Test/NoXS.pm
+++ b/lib/Test/NoXS.pm
@@ -5,12 +5,13 @@ package Test::NoXS;
 # VERSION
 
 use Module::CoreList;
+use version;
 
 my @no_xs_modules;
 my $no_xs_all;
 my $xs_core_only;
 
-our $PERL_CORE_VERSION = $];
+our $PERL_CORE_VERSION = $^V;
 
 sub import {
     my $class = shift;
@@ -28,12 +29,13 @@ sub import {
 #die unless module is in core and hasn't been upgraded.
 sub test_module_in_core {
     my $module = shift;
-    die "XS disabled for non-core modules" unless Module::CoreList::is_core( $module );
-    my $core_module_version = $Module::CoreList::version{$PERL_CORE_VERSION}{$module};
+    my $v = version->declare($PERL_CORE_VERSION)->numify;
+    die "XS disabled for non-core modules" unless Module::CoreList::is_core( $module, undef, $v );
+    my $core_module_version = $Module::CoreList::version{$v}{$module};
     my $module_version = $module->VERSION;
     if( $core_module_version != $module_version ) {
         die "$module installed version: $module_version"
-        ." != $core_module_version ( shipped with perl $^V )";
+        ." != $core_module_version ( shipped with perl $PERL_CORE_VERSION )";
     }
     return 1;
 }

--- a/lib/Test/NoXS.pm
+++ b/lib/Test/NoXS.pm
@@ -27,12 +27,12 @@ sub import {
 
 #die unless module is in core and hasn't been upgraded.
 sub test_module_in_core {
-    my $caller = shift;
-    die "XS disabled for non-core modules" unless Module::CoreList::is_core( $caller );
-    my $core_module_version = $Module::CoreList::version{$PERL_CORE_VERSION}{$caller};
-    my $module_version = $caller->VERSION;
+    my $module = shift;
+    die "XS disabled for non-core modules" unless Module::CoreList::is_core( $module );
+    my $core_module_version = $Module::CoreList::version{$PERL_CORE_VERSION}{$module};
+    my $module_version = $module->VERSION;
     if( $core_module_version != $module_version ) {
-        die "$caller installed version: $module_version"
+        die "$module installed version: $module_version"
         ." != $core_module_version ( shipped with perl $^V )";
     }
     return 1;

--- a/t/03_xs_core_only.t
+++ b/t/03_xs_core_only.t
@@ -25,8 +25,7 @@ is( $@, q{}, "told Test::NoXS only to allow core modules to load XS" );
 };
 
 {
-    local $Test::NoXS::PERL_CORE_VERSION =
-      5.014002;    #version 1.23 for List::Util
+    local $Test::NoXS::PERL_CORE_VERSION = 'v5.14.2';    #version 1.23 for List::Util
     ok Test::NoXS::test_module_in_core('List::Util'),
 "Mock perl version $Test::NoXS::PERL_CORE_VERSION and Mock List::Util version 1.23";
 
@@ -34,6 +33,5 @@ is( $@, q{}, "told Test::NoXS only to allow core modules to load XS" );
         Test::NoXS::test_module_in_core('Cwd');
         fail "should never get here";
     };
-    like $@, '/3\.99/',
-      "Died when I found version 3.99 when looking for version 3.36 of Cwd.";
+    like $@, '/3\.99/',"Died properly: $@";
 };

--- a/t/03_xs_core_only.t
+++ b/t/03_xs_core_only.t
@@ -3,14 +3,14 @@ use warnings;
 use Test::More;
 plan tests => 4;
 
-require_ok( 'Test::NoXS' );
+require_ok('Test::NoXS');
 eval "use Test::NoXS ':xs_core_only'";
 
-
-is( $@, q{},  "told Test::NoXS only to allow core modules to load XS" );
+is( $@, q{}, "told Test::NoXS only to allow core modules to load XS" );
 
 #Mock List::Util that *is* in Core.
 {
+
     package List::Util;
     our $VERSION = 1.23;
     1;
@@ -18,19 +18,22 @@ is( $@, q{},  "told Test::NoXS only to allow core modules to load XS" );
 
 #Mock Cwd that *isn't* in core
 {
+
     package Cwd;
     our $VERSION = 3.99;
     1;
 };
+
 {
-    local $Test::NoXS::PERL_CORE_VERSION = 5.014002; #version 1.23 for List::Util
+    local $Test::NoXS::PERL_CORE_VERSION =
+      5.014002;    #version 1.23 for List::Util
     ok Test::NoXS::test_module_in_core('List::Util'),
 "Mock perl version $Test::NoXS::PERL_CORE_VERSION and Mock List::Util version 1.23";
 
-    eval { 
+    eval {
         Test::NoXS::test_module_in_core('Cwd');
         fail "should never get here";
     };
-    like $@, '/3\.99/', "Died when I found version 3.99 when looking for version 3.36 of Cwd.";
+    like $@, '/3\.99/',
+      "Died when I found version 3.99 when looking for version 3.36 of Cwd.";
 };
-1;

--- a/t/03_xs_core_only.t
+++ b/t/03_xs_core_only.t
@@ -1,7 +1,36 @@
-# Test::NoXS tests
 use strict;
 use warnings;
 use Test::More;
-use Test::NoXS ':xs_core_only';
-use List::Util;
+plan tests => 4;
+
+require_ok( 'Test::NoXS' );
+eval "use Test::NoXS ':xs_core_only'";
+
+
+is( $@, q{},  "told Test::NoXS only to allow core modules to load XS" );
+
+#Mock List::Util that *is* in Core.
+{
+    package List::Util;
+    our $VERSION = 1.23;
+    1;
+};
+
+#Mock Cwd that *isn't* in core
+{
+    package Cwd;
+    our $VERSION = 3.99;
+    1;
+};
+{
+    local $Test::NoXS::PERL_CORE_VERSION = 5.014002; #version 1.23 for List::Util
+    ok Test::NoXS::test_module_in_core('List::Util'),
+"Mock perl version $Test::NoXS::PERL_CORE_VERSION and Mock List::Util version 1.23";
+
+    eval { 
+        Test::NoXS::test_module_in_core('Cwd');
+        fail "should never get here";
+    };
+    like $@, '/3\.99/', "Died when I found version 3.99 when looking for version 3.36 of Cwd.";
+};
 1;

--- a/t/03_xs_core_only.t
+++ b/t/03_xs_core_only.t
@@ -1,0 +1,7 @@
+# Test::NoXS tests
+use strict;
+use warnings;
+use Test::More;
+use Test::NoXS ':xs_core_only';
+use List::Util;
+1;


### PR DESCRIPTION
Added the :xs_core_only feature, documented, added the new prereq to dist.ini, and added a test in for it's usage. Unfortunately I had to mock a lot of the test because there's no real way to produce version mismatches on arbitrary test environments.
Not sure if version.pm should be used, but it does make the error messages look a little cleaner.
